### PR TITLE
fix(social): enlazar el Instagram correcto de Jetour (jetour.honduras)

### DIFF
--- a/src/app/(modules)/(landing)/components/footer.tsx
+++ b/src/app/(modules)/(landing)/components/footer.tsx
@@ -149,7 +149,7 @@ export function Footer({ primaryColor = "#FF7A00" }: FooterProps) {
               <h3 className="text-lg font-bold mb-4">Síguenos</h3>
               <div className="flex space-x-4 mb-6">
                 <a
-                  href="https://www.instagram.com/p/DHZk14Ezyqb/?igsh=YXR4cGVhbnJsbnd3"
+                  href="https://www.instagram.com/jetour.honduras/"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="w-10 h-10 rounded-full flex items-center justify-center border border-gray-300 hover:bg-gray-200 transition-colors"

--- a/src/app/(modules)/(landing)/contactanos/page.tsx
+++ b/src/app/(modules)/(landing)/contactanos/page.tsx
@@ -148,7 +148,7 @@ export default function ContactPage() {
                     </svg>
                   </a>
                   <a
-                    href="https://instagram.com/jejourhonduras"
+                    href="https://www.instagram.com/jetour.honduras/"
                     className="h-12 w-12 rounded-full bg-[#FF7A00] flex items-center justify-center text-white hover:bg-[#E06800] transition-colors"
                     target="_blank"
                     rel="noopener noreferrer"

--- a/src/components/seo/home-page-schema.tsx
+++ b/src/components/seo/home-page-schema.tsx
@@ -59,7 +59,7 @@ export default function HomePageSchema() {
         closes: '00:00'
       }
     ],
-    sameAs: ['https://www.facebook.com/jetourhonduras', 'https://www.instagram.com/jetourhonduras']
+    sameAs: ['https://www.facebook.com/jetourhonduras', 'https://www.instagram.com/jetour.honduras/']
   };
 
   return (

--- a/src/components/seo/organization-schema.tsx
+++ b/src/components/seo/organization-schema.tsx
@@ -29,7 +29,7 @@ export default function OrganizationSchema() {
       telephone: '[+504-3362-0335]',
       email: 'info@jetourhn.com'
     },
-    sameAs: ['https://www.facebook.com/jetourhonduras', 'https://www.instagram.com/jetourhonduras'],
+    sameAs: ['https://www.facebook.com/jetourhonduras', 'https://www.instagram.com/jetour.honduras/'],
     openingHoursSpecification: [
       {
         '@type': 'OpeningHoursSpecification',


### PR DESCRIPTION
## Resumen
Corrige el enlace de Instagram para que apunte al **perfil correcto**: https://www.instagram.com/jetour.honduras/

- **Footer:** el botón de Instagram apuntaba a una publicación específica (`/p/DHZk14Ezyqb/…`) en vez del perfil → corregido.
- **Contáctanos:** el ícono de Instagram tenía un handle con typo (`jejourhonduras`) → corregido.
- **SEO (`sameAs`):** datos estructurados con handle sin punto (`jetourhonduras`) en `organization-schema` y `home-page-schema` → corregidos.

4 archivos, solo cambia URLs.

> Nota aparte: Facebook y TikTok en Contáctanos también tienen el mismo typo de handle (`jejourhonduras`). No los toqué porque el pedido era solo Instagram — puedo corregirlos en otro PR si querés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
